### PR TITLE
Feat/improvements reminder app wpb 17902

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **Note:** This app is in development and not ready for production use.
 
 ## Overview
-This is an app that can create reminders for you and your group, and send you a message when the reminder is due.
+This is an app that can create reminders for conversation, and send a message when the reminder is due.
 
 ## **Features**
 - Set one-time reminders
@@ -14,7 +14,7 @@ This is an app that can create reminders for you and your group, and send you a 
 - Delete reminders
 
 > [!IMPORTANT]  
-> As of now, the bot only supports a maximum of 3 active reminders per group, and recurrent reminders are supported only up to 5 repetitions.
+> As of now, the bot only supports a maximum of 5 active reminders per group, and recurrent reminders are supported only up to 5 repetitions.
 
 ## Getting started
 
@@ -34,13 +34,15 @@ This is an app that can create reminders for you and your group, and send you a 
 
 ### Set reminders examples:
 
-|                    | Command      | What                                           | When                      |
-|--------------------|--------------|------------------------------------------------|---------------------------|
-| one time reminder  | `/remind to` | `"Fill in your invoices by end of day"`        | `"tomorrow at 17:30"`     |
-| one time reminder  | `/remind to` | `"Reply to HR email"`                          | `"in 10 minutes"`         |
-| one time reminder  | `/remind to` | `"Travel back in time to not develop the bot"` | `"11/11/2150"`            |
-| recurrent reminder | `/remind to` | `"Join the daily stand-up"`                    | `"every day at 10:00"`    |
-| recurrent reminder | `/remind to` | `"Empty the unread emails"`                    | `"every friday at 17:00"` |
+|                    | Command      | What                                           | When                                |
+|--------------------|--------------|------------------------------------------------|-------------------------------------|
+| one time reminder  | `/remind to` | `"Fill in your invoices by end of day"`        | `"tomorrow at 17:30"`               |
+| one time reminder  | `/remind to` | `"Fill in your invoices by end of day"`        | `"next Tue at 17:30"`               |
+| one time reminder  | `/remind to` | `"Reply to HR email"`                          | `"in 10 minutes"`                   |
+| one time reminder  | `/remind to` | `"Travel back in time to not develop the bot"` | `"11/11/2150"`                      |
+| recurrent reminder | `/remind to` | `"Join the daily stand-up"`                    | `"every day at 10:00"`              |
+| recurrent reminder | `/remind to` | `"Empty the unread emails"`                    | `"every Friday at 17:00"`           |
+| recurrent reminder | `/remind to` | `"Empty the unread emails"`                    | `"every Mon, TUE, friday at 17:00"` |
 
 > [!TIP]  
 > You can set reminders for yourself. To do so, you can use the commands in a private conversation, a 1:1 with the bot.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     kotlin("jvm") version "2.1.20"
@@ -10,6 +11,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
     id("io.gitlab.arturbosch.detekt") version "1.23.7"
     id("io.quarkus")
+    id("com.gradleup.shadow") version "8.3.6"
 }
 
 repositories {
@@ -53,7 +55,7 @@ dependencies {
     implementation("com.rubiconproject.oss:jchronic:0.2.8")
     implementation("io.github.yamilmedina:natural-kron:2.0.0")
     implementation("io.arrow-kt:arrow-core:1.2.0-RC")
-    implementation("com.wire:wire-apps-jvm-sdk:0.0.7")
+    implementation("com.wire:wire-apps-jvm-sdk:0.0.8")
 
     // Test dependencies
     testImplementation("io.quarkus:quarkus-junit5")
@@ -107,4 +109,8 @@ tasks.withType<KotlinJvmCompile>().configureEach {
         jvmTarget.set(JvmTarget.JVM_17)
         javaParameters.set(true)
     }
+}
+
+tasks.named<ShadowJar>("shadowJar") {
+    mergeServiceFiles()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.22.1
+quarkusPluginVersion=3.22.3
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.22.1
+quarkusPlatformVersion=3.22.3

--- a/src/main/kotlin/com/wire/bots/application/EventMapper.kt
+++ b/src/main/kotlin/com/wire/bots/application/EventMapper.kt
@@ -127,9 +127,9 @@ internal val COMMAND_HINT =
     """
     Unknown command, valid options are:
     ```
-    > /remind help
-    > /remind list
-    > /remind to "what" "when"
-    > /remind delete <reminderId>
+    /remind help
+    /remind list
+    /remind to "what" "when"
+    /remind delete <reminderId>
     ```
     """.trimIndent()

--- a/src/main/kotlin/com/wire/bots/application/EventMapper.kt
+++ b/src/main/kotlin/com/wire/bots/application/EventMapper.kt
@@ -72,33 +72,36 @@ object EventMapper {
         conversationId: QualifiedId,
         args: String
     ): Either<BotError, Command> {
-        val reminderArgs = args
-            .substringAfter("to")
-            .split('"', '“')
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
-        if (reminderArgs.size != 2) {
-            return BotError
-                .ReminderError(
-                    conversationId = conversationId,
-                    errorType = BotError.ErrorType.INVALID_REMINDER_USAGE
-                ).left()
-        } else if (reminderArgs[0].isBlank()) {
-            return BotError
-                .ReminderError(
-                    conversationId = conversationId,
-                    errorType = BotError.ErrorType.EMPTY_REMINDER_TASK
-                ).left()
-        }
-        val (task, schedule) = reminderArgs
-        return ReminderMapper
-            .parseReminder(
+        val regex = Regex("[\"“]([^\"“]*)[\"“]")
+        val matches = regex.findAll(args.substringAfter("to"))
+            .map { it.groupValues[1] }
+            .toList()
+        return when {
+            matches.size < 2 -> BotError.ReminderError(
                 conversationId = conversationId,
-                task = task,
-                schedule = schedule
-            ).mapLeft { error ->
-                error as? BotError.ReminderError ?: error("Unexpected error type: $error")
+                errorType = BotError.ErrorType.INVALID_REMINDER_USAGE
+            ).left()
+            matches[0].isBlank() -> BotError.ReminderError(
+                conversationId = conversationId,
+                errorType = BotError.ErrorType.EMPTY_REMINDER_TASK
+            ).left()
+            matches[1].isBlank() -> BotError.ReminderError(
+                conversationId = conversationId,
+                errorType = BotError.ErrorType.INVALID_REMINDER_USAGE
+            ).left()
+            else -> {
+                val task = matches[0]
+                val schedule = matches[1]
+                ReminderMapper
+                    .parseReminder(
+                        conversationId = conversationId,
+                        task = task,
+                        schedule = schedule
+                    ).mapLeft { error ->
+                        error as? BotError.ReminderError ?: error("❌ Unexpected error type: $error")
+                    }
             }
+        }
     }
 
     private fun parseDeleteCommand(

--- a/src/main/kotlin/com/wire/bots/application/EventMapper.kt
+++ b/src/main/kotlin/com/wire/bots/application/EventMapper.kt
@@ -72,7 +72,7 @@ object EventMapper {
         conversationId: QualifiedId,
         args: String
     ): Either<BotError, Command> {
-        val regex = Regex("[\"“]([^\"“]*)[\"“]")
+        val regex = Regex("[\"“”]([^\"“”]*)[\"“”]")
         val matches = regex.findAll(args.substringAfter("to"))
             .map { it.groupValues[1] }
             .toList()

--- a/src/main/kotlin/com/wire/bots/application/MlsSdkClient.kt
+++ b/src/main/kotlin/com/wire/bots/application/MlsSdkClient.kt
@@ -58,7 +58,8 @@ class MlsSdkClient(
                 apiHost = apiHost,
                 cryptographyStoragePassword = "myDummyPassword",
                 wireEventsHandler = object : WireEventsHandlerSuspending() {
-                    override suspend fun onMessage(wireMessage: WireMessage.Text) =
+                    override suspend fun onMessage(wireMessage: WireMessage.Text) {
+                        logger.info("Received Text Message : $wireMessage")
                         processEvent(
                             EventDTO(
                                 type = EventTypeDTO.NEW_TEXT,
@@ -67,6 +68,15 @@ class MlsSdkClient(
                                 text = wireMessage.text.let { TextContent(it) }
                             )
                         )
+
+                        // Sending a Read Receipt for the received message
+                        val receipt = WireMessage.Receipt.create(
+                            conversationId = wireMessage.conversationId,
+                            type = WireMessage.Receipt.Type.READ,
+                            messages = listOf(wireMessage.id.toString())
+                        )
+                        manager.sendMessageSuspending(message = receipt)
+                    }
 
                     override suspend fun onAsset(wireMessage: WireMessage.Asset) {
                         logger.info("Received Asset Message: $wireMessage")

--- a/src/main/kotlin/com/wire/bots/application/ReminderMapper.kt
+++ b/src/main/kotlin/com/wire/bots/application/ReminderMapper.kt
@@ -9,17 +9,15 @@ import com.mdimension.jchronic.tags.Pointer
 import com.wire.bots.domain.event.BotError
 import com.wire.bots.domain.event.Command
 import com.wire.bots.domain.reminder.Reminder
-import io.github.yamilmedina.kron.NaturalKronParser
 import java.util.UUID
 import com.wire.integrations.jvm.model.QualifiedId
 import com.wire.bots.domain.usecase.ValidateReminder
+import com.wire.bots.infrastructure.utils.CronInterpreter
 
 object ReminderMapper {
     private val INVALID_TIME_TOKENS = listOf("hour", "minute", "second")
     private val VALID_RECURRENT_TOKENS = listOf("every")
     // todo: expand later, each, daily, weekly, etc.
-
-    private val naturalKronParser = NaturalKronParser()
 
     private fun isRecurrentSchedule(schedule: String): Boolean =
         VALID_RECURRENT_TOKENS.any { schedule.contains(it) }
@@ -103,7 +101,7 @@ object ReminderMapper {
                         conversationId = conversationId,
                         taskId = UUID.randomUUID().toString(),
                         task = task,
-                        scheduledCron = naturalKronParser.parse(schedule)
+                        scheduledCron = CronInterpreter.textToCron(schedule)
                     )
                 ).right()
         }.getOrElse {

--- a/src/main/kotlin/com/wire/bots/application/ReminderMapper.kt
+++ b/src/main/kotlin/com/wire/bots/application/ReminderMapper.kt
@@ -29,8 +29,9 @@ object ReminderMapper {
         conversationId: QualifiedId,
         task: String,
         schedule: String
-    ): Either<BotError, Command> =
-        when {
+    ): Either<BotError, Command> {
+        ValidateReminder.validateTaskNotEmpty(task, conversationId)?.let { return it.left() }
+        return when {
             isRecurrentSchedule(schedule) && containsInvalidTimeTokens(schedule) -> {
                 BotError
                     .ReminderError(

--- a/src/main/kotlin/com/wire/bots/domain/event/Event.kt
+++ b/src/main/kotlin/com/wire/bots/domain/event/Event.kt
@@ -90,7 +90,21 @@ sealed class BotError(
         ),
         PARSE_ERROR(
             "❌ I'm sorry, I didn't catch that. I can get a little confused at times. " +
-                "Please try again with a different format or see examples with **`/remind help`**."
+                "Please try again with a different format or see examples with `/remind help`."
+        ),
+        EMPTY_REMINDER_TASK(
+            "❌ Reminder message can't be empty. Please provide what you want to be reminded about."
+        ),
+        INVALID_REMINDER_ID(
+            "❌ Invalid reminder ID. Please provide a valid reminder ID to delete."
+        ),
+        INVALID_REMINDER_USAGE(
+            "❌ Invalid reminder usage. Please use the correct format:\n" +
+                """
+                ```
+                /remind to "What" "When"
+                ```
+                """.trimIndent()
         )
     }
 }

--- a/src/main/kotlin/com/wire/bots/domain/event/EventProcessor.kt
+++ b/src/main/kotlin/com/wire/bots/domain/event/EventProcessor.kt
@@ -56,6 +56,9 @@ class EventProcessor(
     private fun handleErrorMessage(error: BotError): Either<Throwable, Unit> =
         outgoingMessageRepository.sendMessage(
             conversationId = error.conversationId,
-            messageContent = error.reason
+            messageContent = when (error) {
+                is BotError.ReminderError -> error.errorType.message
+                else -> error.reason
+            }
         )
 }

--- a/src/main/kotlin/com/wire/bots/domain/event/EventProcessor.kt
+++ b/src/main/kotlin/com/wire/bots/domain/event/EventProcessor.kt
@@ -37,7 +37,7 @@ class EventProcessor(
             "❌ Maximum numbers of active reminders reached (currently ${error.max})." +
                 "Please delete some reminders first."
         } else {
-            "An error occurred while processing the command, please try again later."
+            "❌ An error occurred while processing the command, please try again later."
         }
 
     fun process(error: BotError): Either<Throwable, Unit> =

--- a/src/main/kotlin/com/wire/bots/domain/event/handlers/CommandHandler.kt
+++ b/src/main/kotlin/com/wire/bots/domain/event/handlers/CommandHandler.kt
@@ -96,14 +96,22 @@ class CommandHandler(
                 "I will remind you to **'${reminder.task}'** at:\n" +
                     "**${reminderNextSchedule.nextSchedules.first()}**.\n" +
                     "If you want to delete it, you can use the command:\n" +
-                    "`/remind delete ${reminder.taskId}`"
+                    """
+                    ```
+                    /remind delete ${reminder.taskId}
+                    ```
+                    """.trimIndent()
             }
 
             is Reminder.RecurringReminder -> {
                 "I will periodically remind you to **'${reminder.task}'**.\n" +
                     "If you want to delete it, you can use the command:\n" +
-                    "`/remind delete ${reminder.taskId}`\n\n" +
-                    "The next ${reminderNextSchedule.nextSchedules.size} " +
+                    """
+                    ```
+                    /remind delete ${reminder.taskId}
+                    ```
+                    """.trimIndent() +
+                    "\nThe next ${reminderNextSchedule.nextSchedules.size} " +
                     "schedules for the reminder is:\n" +
                     reminderNextSchedule.nextSchedules.joinToString("\n") {
                         "- $it"
@@ -120,27 +128,30 @@ class CommandHandler(
 
         fun createHelpMessage(): String =
             """
-            Hi, I'm the Remind App.
-            I can help you to create reminders for your conversations, or yourself.
+            **Hi, I'm the Remind App.**
+            **I can help you to create reminders for your conversations, or yourself.**
             
-            1. You can start by creating a reminder with the following event, some valid examples are:
-            
-            `/remind to "do something" "in 5 minutes"`
-            `/remind to "do something" "today at 21:00"`
-            `/remind to "do something" "18/09/2024 at 09:45"`
-            `/remind to "do something" "next monday at 17:00"`
-            
-            You can also create a reminder that repeats, for example:
-            
-            `/remind to "Start the daily stand up" "every day at 10:00"`
-            
-            2. You can list all the active reminders in the conversation with the following event:
-            
-            `/remind list`
-            
-            3. And you can delete a reminder with the following event:
-            
-            `/remind delete <reminderId>` (you can get the <reminderId> from the list event)
+            1. You can create one time reminders, for example:
+            ```
+            /remind to "do something" "in 5 minutes"
+            /remind to "do something" "today at 21:00"
+            /remind to "do something" "18/09/2025 at 09:45"
+            /remind to "do something" "next monday at 17:00"
+            ```
+            2. You can also create a recurring reminders, for example:
+            ```
+            /remind to "Start the daily stand up" "every day at 10:00"
+            /remind to "Start the weekly stand up" "every friday at 10:00"
+            ```
+            3. You can list all the active reminders in the conversation with the following event:
+            ```
+            /remind list
+            ```
+            4. And you can delete a reminder with the following event:
+            (you can get the <reminderId> from the `/remind list` command)
+            ```
+            /remind delete <reminderId>
+            ```
             """.trimIndent()
     }
 }

--- a/src/main/kotlin/com/wire/bots/domain/event/handlers/CommandHandler.kt
+++ b/src/main/kotlin/com/wire/bots/domain/event/handlers/CommandHandler.kt
@@ -126,16 +126,13 @@ class CommandHandler(
 
     companion object {
         fun createLegacyHelpMessage(): String =
-            """
-            Hi, I'm the Remind App.
-            Please use my specific help event **`/remind help`** to get more information about how to use me.
-            """.trimIndent()
+            "**Hi, I\\'m the Remind App.**\nPlease use my specific help command\n" +
+                "```\n/remind help\n```\n"
 
         fun createHelpMessage(): String =
             """
             **Hi, I'm the Remind App.**
             **I can help you to create reminders for your conversations, or yourself.**
-            
             1. You can create one time reminders, for example:
             ```
             /remind to "do something" "in 5 minutes"
@@ -150,12 +147,12 @@ class CommandHandler(
             /remind to "Start the weekly stand up" "every Monday at 10:00"
             /remind to "Start the weekly stand up" "every MON, Tue, Friday at 10:00"
             ```
-            3. You can list all the active reminders in the conversation with the following event:
+            3. You can list all the active reminders in the conversation with the following command:
             ```
             /remind list
             ```
-            4. And you can delete a reminder with the following command:
-            (you can get the <reminderId> from the `/remind list` command)
+            4. You can delete a reminder with the following command:
+            (Get the <reminderId> from the `/remind list` command)
             ```
             /remind delete <reminderId>
             ```

--- a/src/main/kotlin/com/wire/bots/domain/event/handlers/CommandHandler.kt
+++ b/src/main/kotlin/com/wire/bots/domain/event/handlers/CommandHandler.kt
@@ -46,7 +46,7 @@ class CommandHandler(
                 } else {
                     "The reminders in this conversation:\n" +
                         reminders.joinToString("\n") {
-                            "What: '${it.task}' at: ${
+                            "'${it.task}' at: ${
                                 when (it) {
                                     is Reminder.SingleReminder -> it.scheduledAt
                                     is Reminder.RecurringReminder -> CronInterpreter.cronToText(
@@ -90,7 +90,7 @@ class CommandHandler(
             } else {
                 outgoingMessageRepository.sendMessage(
                     conversationId = command.conversationId,
-                    messageContent = "The reminder with id '${command.reminderId}' was not found."
+                    messageContent = "❌ The reminder with id '${command.reminderId}' was not found."
                 )
             }
         }
@@ -143,16 +143,18 @@ class CommandHandler(
             /remind to "do something" "18/09/2025 at 09:45"
             /remind to "do something" "next monday at 17:00"
             ```
-            2. You can also create a recurring reminders, for example:
+            2. You can also create recurring reminders, for example:
             ```
             /remind to "Start the daily stand up" "every day at 10:00"
-            /remind to "Start the weekly stand up" "every friday at 10:00"
+            /remind to "Start the weekly stand up" "every weekday at 10:00"
+            /remind to "Start the weekly stand up" "every Monday at 10:00"
+            /remind to "Start the weekly stand up" "every MON, Tue, Friday at 10:00"
             ```
             3. You can list all the active reminders in the conversation with the following event:
             ```
             /remind list
             ```
-            4. And you can delete a reminder with the following event:
+            4. And you can delete a reminder with the following command:
             (you can get the <reminderId> from the `/remind list` command)
             ```
             /remind delete <reminderId>

--- a/src/main/kotlin/com/wire/bots/domain/event/handlers/CommandHandler.kt
+++ b/src/main/kotlin/com/wire/bots/domain/event/handlers/CommandHandler.kt
@@ -49,11 +49,16 @@ class CommandHandler(
                             "What: '${it.task}' at: ${
                                 when (it) {
                                     is Reminder.SingleReminder -> it.scheduledAt
-                                    is Reminder.RecurringReminder -> CronInterpreter.interpretCron(
+                                    is Reminder.RecurringReminder -> CronInterpreter.cronToText(
                                         it.scheduledCron
                                     )
                                 }
-                            } (`${it.taskId}`)"
+                            }\n" +
+                                """
+                                ```
+                                /remind delete ${it.taskId}
+                                ```
+                                """.trimIndent()
                         }
                 }
 

--- a/src/main/kotlin/com/wire/bots/domain/usecase/SaveReminderSchedule.kt
+++ b/src/main/kotlin/com/wire/bots/domain/usecase/SaveReminderSchedule.kt
@@ -44,7 +44,7 @@ class SaveReminderSchedule(
 
     data class MaxReminderJobsReached(
         val max: Int = MAX_REMINDER_JOBS
-    ) : Throwable("Max reminder jobs reached: $max")
+    ) : Throwable("❌ Max reminder jobs reached: $max")
 
     companion object {
         private const val MAX_REMINDER_JOBS = 5

--- a/src/main/kotlin/com/wire/bots/domain/usecase/SaveReminderSchedule.kt
+++ b/src/main/kotlin/com/wire/bots/domain/usecase/SaveReminderSchedule.kt
@@ -47,6 +47,6 @@ class SaveReminderSchedule(
     ) : Throwable("Max reminder jobs reached: $max")
 
     companion object {
-        private const val MAX_REMINDER_JOBS = 3
+        private const val MAX_REMINDER_JOBS = 5
     }
 }

--- a/src/main/kotlin/com/wire/bots/domain/usecase/ValidateReminder.kt
+++ b/src/main/kotlin/com/wire/bots/domain/usecase/ValidateReminder.kt
@@ -1,8 +1,33 @@
 package com.wire.bots.domain.usecase
 
-class ValidateReminder {
-    // TODO: Implement validation:
-    // - reminder should not be empty
-    // - scheduled time should be in the future
-    // - limit reminders to MAX_REMINDERS_PER_CONVERSATION = 3
+import com.wire.bots.domain.event.BotError
+import com.wire.integrations.jvm.model.QualifiedId
+import java.time.Instant
+
+object ValidateReminder {
+    fun validateTaskNotEmpty(
+        task: String,
+        conversationId: QualifiedId
+    ): BotError.ReminderError? =
+        if (task.isBlank()) {
+            BotError.ReminderError(
+                conversationId = conversationId,
+                errorType = BotError.ErrorType.PARSE_ERROR
+            )
+        } else {
+            null
+        }
+
+    fun validateScheduledTimeInFuture(
+        scheduledAt: Instant,
+        conversationId: QualifiedId
+    ): BotError.ReminderError? =
+        if (scheduledAt.isBefore(Instant.now())) {
+            BotError.ReminderError(
+                conversationId = conversationId,
+                errorType = BotError.ErrorType.DATE_IN_PAST
+            )
+        } else {
+            null
+        }
 }

--- a/src/main/kotlin/com/wire/bots/domain/usecase/ValidateReminder.kt
+++ b/src/main/kotlin/com/wire/bots/domain/usecase/ValidateReminder.kt
@@ -12,7 +12,7 @@ object ValidateReminder {
         if (task.isBlank()) {
             BotError.ReminderError(
                 conversationId = conversationId,
-                errorType = BotError.ErrorType.PARSE_ERROR
+                errorType = BotError.ErrorType.EMPTY_REMINDER_TASK
             )
         } else {
             null

--- a/src/main/kotlin/com/wire/bots/infrastructure/jobs/ReminderJob.kt
+++ b/src/main/kotlin/com/wire/bots/infrastructure/jobs/ReminderJob.kt
@@ -6,8 +6,8 @@ import org.quartz.JobExecutionContext
 import org.quartz.JobExecutionException
 import org.slf4j.LoggerFactory
 
-class ReminderJob(
-    @Inject val reminderTaskExecutor: ReminderTaskExecutor
+class ReminderJob @Inject constructor(
+    private val reminderTaskExecutor: ReminderTaskExecutor
 ) : Job {
     private val logger = LoggerFactory.getLogger(this::class.java)
 

--- a/src/main/kotlin/com/wire/bots/infrastructure/repository/DefaultReminderJobRepository.kt
+++ b/src/main/kotlin/com/wire/bots/infrastructure/repository/DefaultReminderJobRepository.kt
@@ -105,7 +105,7 @@ class DefaultReminderJobRepository(
      */
     private fun getNextFireTimeForTrigger(
         trigger: Trigger,
-        maxNextFireSize: Int = 3
+        maxNextFireSize: Int = 5
     ): List<Date> {
         val runs: MutableList<Date> = ArrayList()
         var next = trigger.nextFireTime
@@ -120,6 +120,6 @@ class DefaultReminderJobRepository(
     companion object {
         private const val SECONDS_BEFORE_WARMUP = 10L
         private const val SINGLE_TIME_COUNT_JOB = 1
-        private const val MAX_NEXT_FIRE_SIZE = 3
+        private const val MAX_NEXT_FIRE_SIZE = 5
     }
 }

--- a/src/main/kotlin/com/wire/bots/infrastructure/utils/CronInterpreter.kt
+++ b/src/main/kotlin/com/wire/bots/infrastructure/utils/CronInterpreter.kt
@@ -9,7 +9,7 @@ object CronInterpreter {
     private const val CRON_MONTH_INDEX = 4
     private const val CRON_WEEKDAY_INDEX = 5
 
-    fun interpretCron(cron: String): String {
+    fun cronToText(cron: String): String {
         val parts = cron.trim().split("\\s+".toRegex())
         if (parts.size < CRON_PARTS_SIZE) return "(invalid cron)"
 
@@ -23,6 +23,32 @@ object CronInterpreter {
                 "${formatHour(parts)}:${formatMinute(parts)}"
             else -> "every (custom cron: $cron)"
         }
+    }
+
+    fun textToCron(text: String): String {
+        val lower = text.trim().lowercase()
+        val timeRegex = Regex("(\\d{1,2}):(\\d{2})")
+        val timeMatch = timeRegex.find(lower)
+        val (hour, minute) = timeMatch?.destructured?.let {
+            it.component1() to it.component2()
+        } ?: ("10" to "00")
+
+        val dayMap = mapOf(
+            "mon" to "MON", "monday" to "MON",
+            "tue" to "TUE", "tuesday" to "TUE",
+            "wed" to "WED", "wednesday" to "WED",
+            "thu" to "THU", "thursday" to "THU",
+            "fri" to "FRI", "friday" to "FRI",
+            "sat" to "SAT", "saturday" to "SAT",
+            "sun" to "SUN", "sunday" to "SUN"
+        )
+
+        val days = Helpers.extractDays(lower, dayMap)
+        if (days != null) {
+            return "0 $minute $hour ? * $days"
+        }
+
+        return Helpers.mapTextToCron(lower, hour, minute)
     }
 
     private fun isEveryHour(parts: List<String>) =
@@ -53,4 +79,52 @@ object CronInterpreter {
     private fun formatHour(parts: List<String>) = parts[CRON_HOUR_INDEX].padStart(2, '0')
 
     private fun formatMinute(parts: List<String>) = parts[CRON_MINUTE_INDEX].padStart(2, '0')
+
+    private object Helpers {
+        private const val DAY_NAME_LENGTH = 3
+
+        /**
+         * Extracts days from a string like "every mon, tue, wed" or "every monday, tuesday, wednesday".
+         * Returns a comma-separated string of the corresponding cron day abbreviations.
+         */
+        fun extractDays(
+            lower: String,
+            dayMap: Map<String, String>
+        ): String? {
+            // Find the 'every ...' part and extract day tokens
+            val everyPattern = Regex("every ([^@\\d]+)", RegexOption.IGNORE_CASE)
+            val match = everyPattern.find(lower)
+            val daysRaw = match?.groupValues?.get(1) ?: return null
+            // Split by comma or space, trim, and filter out empty
+            val tokens = daysRaw.split(",", " ")
+                .map { it.trim().lowercase() }
+                .filter { it.isNotBlank() }
+            // Map both short and full names, deduplicate, preserve order
+            val seen = mutableSetOf<String>()
+            val cronDays = tokens.mapNotNull { token ->
+                val key = if (token.length > DAY_NAME_LENGTH) token.take(DAY_NAME_LENGTH) else token
+                dayMap[key] ?: dayMap[token]
+            }.filter { seen.add(it) }
+            return if (cronDays.isNotEmpty()) cronDays.joinToString(",") else null
+        }
+
+        fun mapTextToCron(
+            lower: String,
+            hour: String,
+            minute: String
+        ): String {
+            return when {
+                lower.contains("every day") -> "0 $minute $hour * * ?"
+                lower.contains("every weekday") -> "0 $minute $hour ? * MON-FRI"
+                lower.contains("every monday") -> "0 $minute $hour ? * MON"
+                lower.contains("every tuesday") -> "0 $minute $hour ? * TUE"
+                lower.contains("every wednesday") -> "0 $minute $hour ? * WED"
+                lower.contains("every thursday") -> "0 $minute $hour ? * THU"
+                lower.contains("every friday") -> "0 $minute $hour ? * FRI"
+                lower.contains("every saturday") -> "0 $minute $hour ? * SAT"
+                lower.contains("every sunday") -> "0 $minute $hour ? * SUN"
+                else -> throw IllegalArgumentException("Unsupported schedule: $lower")
+            }
+        }
+    }
 }

--- a/src/test/kotlin/com/wire/bots/CronInterpreterTest.kt
+++ b/src/test/kotlin/com/wire/bots/CronInterpreterTest.kt
@@ -8,49 +8,142 @@ class CronInterpreterTest {
     @Test
     fun `should return every hour for valid hourly cron`() {
         val cron = "* * * * * *"
-        val result = CronInterpreter.interpretCron(cron)
+        val result = CronInterpreter.cronToText(cron)
         assertEquals("every hour", result)
     }
 
     @Test
     fun `should return every day at specific hour for valid daily cron`() {
         val cron = "0 0 10 ? * *"
-        val result = CronInterpreter.interpretCron(cron)
+        val result = CronInterpreter.cronToText(cron)
         assertEquals("every day at 10:00", result)
     }
 
     @Test
     fun `should return every day at specific time for valid daily cron`() {
         val cron = "0 30 14 * * *"
-        val result = CronInterpreter.interpretCron(cron)
+        val result = CronInterpreter.cronToText(cron)
         assertEquals("every day at 14:30", result)
     }
 
     @Test
     fun `should return every month on specific day for valid monthly cron`() {
         val cron = "0 15 8 5 * *"
-        val result = CronInterpreter.interpretCron(cron)
+        val result = CronInterpreter.cronToText(cron)
         assertEquals("every month on day 5 at 08:15", result)
     }
 
     @Test
     fun `should return every week on specific day for valid weekly cron`() {
         val cron = "0 45 16 ? * MON"
-        val result = CronInterpreter.interpretCron(cron)
+        val result = CronInterpreter.cronToText(cron)
         assertEquals("every week on MON at 16:45", result)
+    }
+
+    @Test
+    fun `should return every week on multiple days for valid weekly cron`() {
+        val cron = "0 00 10 ? * MON,WED,FRI"
+        val result = CronInterpreter.cronToText(cron)
+        assertEquals("every week on MON,WED,FRI at 10:00", result)
+    }
+
+    @Test
+    fun `should return every week on single day for valid weekly cron`() {
+        val cron = "0 45 16 ? * MON"
+        val result = CronInterpreter.cronToText(cron)
+        assertEquals("every week on MON at 16:45", result)
+    }
+
+    @Test
+    fun `should return every week on multiple days for valid weekly cron with mixed case`() {
+        val cron = "0 15 8 ? * tue,THU,sat"
+        val result = CronInterpreter.cronToText(cron)
+        assertEquals("every week on tue,THU,sat at 08:15", result)
+    }
+
+    @Test
+    fun `should return every week on multiple days for valid weekly cron with all days`() {
+        val cron = "0 00 10 ? * MON,TUE,WED,THU,FRI,SAT,SUN"
+        val result = CronInterpreter.cronToText(cron)
+        assertEquals("every week on MON,TUE,WED,THU,FRI,SAT,SUN at 10:00", result)
+    }
+
+    @Test
+    fun `should return every week on day range for valid weekly cron`() {
+        val cron = "0 00 10 ? * MON-FRI"
+        val result = CronInterpreter.cronToText(cron)
+        assertEquals("every week on MON-FRI at 10:00", result)
     }
 
     @Test
     fun `should return custom cron for unhandled patterns`() {
         val cron = "0 0 12 1 1 ?"
-        val result = CronInterpreter.interpretCron(cron)
+        val result = CronInterpreter.cronToText(cron)
         assertEquals("every (custom cron: $cron)", result)
     }
 
     @Test
     fun `should return invalid cron for malformed input`() {
         val cron = "0 0 12"
-        val result = CronInterpreter.interpretCron(cron)
+        val result = CronInterpreter.cronToText(cron)
         assertEquals("(invalid cron)", result)
+    }
+
+    @Test
+    fun `should parse single short day`() {
+        val cron = CronInterpreter.textToCron("every mon at 10:00")
+        assertEquals("0 00 10 ? * MON", cron)
+    }
+
+    @Test
+    fun `should parse single full day`() {
+        val cron = CronInterpreter.textToCron("every Monday at 10:00")
+        assertEquals("0 00 10 ? * MON", cron)
+    }
+
+    @Test
+    fun `should parse multiple short days`() {
+        val cron = CronInterpreter.textToCron("every mon,wed,fri at 10:00")
+        assertEquals("0 00 10 ? * MON,WED,FRI", cron)
+    }
+
+    @Test
+    fun `should parse multiple full days`() {
+        val cron = CronInterpreter.textToCron("every Monday, Wednesday, Friday at 10:00")
+        assertEquals("0 00 10 ? * MON,WED,FRI", cron)
+    }
+
+    @Test
+    fun `should parse mixed short and full days`() {
+        val cron = CronInterpreter.textToCron("every MON, tuesday, fri at 10:00")
+        assertEquals("0 00 10 ? * MON,TUE,FRI", cron)
+    }
+
+    @Test
+    fun `should deduplicate days and ignore case`() {
+        val cron = CronInterpreter.textToCron("every MON, mon, Mon at 10:00")
+        assertEquals("0 00 10 ? * MON", cron)
+    }
+
+    @Test
+    fun `should parse every day`() {
+        val cron = CronInterpreter.textToCron("every day at 10:00")
+        assertEquals("0 00 10 * * ?", cron)
+    }
+
+    @Test
+    fun `should parse every weekday`() {
+        val cron = CronInterpreter.textToCron("every weekday at 10:00")
+        assertEquals("0 00 10 ? * MON-FRI", cron)
+    }
+
+    @Test
+    fun `should throw on invalid day`() {
+        try {
+            CronInterpreter.textToCron("every blursday at 10:00")
+            assert(false) { "Should have thrown" }
+        } catch (e: IllegalArgumentException) {
+            assert(true)
+        }
     }
 }

--- a/src/test/kotlin/com/wire/bots/application/ReminderMapperTest.kt
+++ b/src/test/kotlin/com/wire/bots/application/ReminderMapperTest.kt
@@ -78,4 +78,46 @@ class ReminderMapperTest {
             )
         }
     }
+
+    @Test
+    fun givenAnEmptyTask_whenParsingReminder_thenRaiseParseError() {
+        val result = ReminderMapper.parseReminder(
+            TEST_CONVERSATION_ID,
+            "   ",
+            "tomorrow at 10:00"
+        )
+        result.shouldFail {
+            assertInstanceOf(BotError.ReminderError::class.java, it)
+            assertEquals(
+                BotError.ErrorType.PARSE_ERROR.message,
+                (it as BotError.ReminderError).reason
+            )
+        }
+    }
+
+    @Test
+    fun givenAnInvalidDate_whenParsingReminder_thenRaiseParseError() {
+        val result = ReminderMapper.parseReminder(
+            TEST_CONVERSATION_ID,
+            "task",
+            "31.02.2025 at 10:00"
+        )
+        result.shouldFail {
+            assertInstanceOf(BotError.ReminderError::class.java, it)
+            assertEquals(
+                BotError.ErrorType.PARSE_ERROR.message,
+                (it as BotError.ReminderError).reason
+            )
+        }
+    }
+
+    @Test
+    fun givenAValidReminder_whenParsingReminder_thenSucceeds() {
+        val result = ReminderMapper.parseReminder(
+            TEST_CONVERSATION_ID,
+            "Buy milk",
+            "tomorrow at 10:00"
+        )
+        assert(result.isRight())
+    }
 }

--- a/src/test/kotlin/com/wire/bots/application/ReminderMapperTest.kt
+++ b/src/test/kotlin/com/wire/bots/application/ReminderMapperTest.kt
@@ -89,7 +89,7 @@ class ReminderMapperTest {
         result.shouldFail {
             assertInstanceOf(BotError.ReminderError::class.java, it)
             assertEquals(
-                BotError.ErrorType.PARSE_ERROR.message,
+                BotError.ErrorType.EMPTY_REMINDER_TASK.message,
                 (it as BotError.ReminderError).reason
             )
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Improved error handling for command argument parsing.
- Enhanced error message consistency and clarity.
- Updated reminder listing to show full delete command for each reminder.
- Improved cron parsing and formatting for recurring reminders.
- Increased the maximum number of active reminders per conversation to 5.
- Resolve all warnings.
- Update WireSDK and Quarkus.
- Add read receipts feature

### Causes (Optional)

- Previous error handling was inconsistent and did not provide clear feedback to users.
- The natural language cron parser was limited in handling various weekday formats.
- Users needed clearer instructions for deleting reminders.
- Build had warnings: ignored value, and dependancies duplicates.

### Solutions

- Refactored error handling and introduced new ErrorType values for better granularity.
- Standardized all error messages with a '❌' prefix.
- Updated the /remind list command to display the full delete command for each reminder.
- Replaced interpretCron() with cronToText() and introduced textToCron() for improved cron parsing, supporting multiple weekday formats.
- Increased the reminder limit per conversation to 5.
- Send read receipts for received messages.

### Dependencies (Optional)

- Update WireSDK to 0.0.8
- Update Quarkus to 3.22.3

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

0. Add credentials in demo.properties
1. Run the db with docker compose up db
2. Build the App with ./gradlew clean build -Dquarkus.package.jar.type=uber-jar
3. Run the app with java -jar build/reminders-bot-1.0.0-SNAPSHOT-runner.jar
4. Login to [chala.wire.link](https://github.com/wireapp/reminder-app/pull/chala.wire.link) with your account
5. Create new conversation
6. Add Remind-App to conversation
7. Send /remind to "Do smth" "every Monday, Tue, FRI at 09:00".
8. Send /remind list to see active reminder full info.
9. Send /remind delete <reminder UUID> to delete any type of reminder by UUID provided with /remind list command.

### Notes (Optional)

- All error messages are now consistent and user-friendly.
- Reminder deletion is now easier with the displayed command.
- Cron parsing is more robust and flexible for user input.


